### PR TITLE
Fix autoloading gdb python extensions.

### DIFF
--- a/python27.spec
+++ b/python27.spec
@@ -330,6 +330,8 @@ chmod 644 $RPM_BUILD_ROOT%{__prefix}/%{libdirname}/libpython%{libvers}*
 #  Tools
 %if %{include_tools}
 cp -a Tools $RPM_BUILD_ROOT%{__prefix}/%{libdirname}/python%{libvers}
+install -D -m 644 Tools/gdb/libpython.py $RPM_BUILD_ROOT%{__prefix}/%{libdirname}/debug/usr/bin/python%{libvers}.debug-gdb.py
+echo "/usr/lib/debug/usr/bin/python2.7.debug-gdb.py" >> debugfiles.list
 %endif
 
 #  MAKE FILE LISTS


### PR DESCRIPTION
Centos package for 2.6 version of python-debuginfo provided a file
/usr/lib/debug/usr/lib64/libpython2.6.so.1.0.debug-gdb.py which cooperates
with gdb so that the commands like "py-bt" are automatically available.

This fix does the analogical thing but it uses
/usr/lib/debug/usr/bin/python2.7.debug-gdb.py as an entry point.

Note: to use debugging with gdb correctly, one still needs to change the spec
to include `--with-pydebug` option in the call to `./configure`. Without this
the frame information is optimized out and gdb is not that usefull.
